### PR TITLE
Add wallet-based approvals and make backend read-only

### DIFF
--- a/tokenxllm/dashboard/backend/main.py
+++ b/tokenxllm/dashboard/backend/main.py
@@ -1,7 +1,5 @@
-import os, re, subprocess
-from typing import Any
+import os
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
 from dotenv import load_dotenv
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -20,18 +18,11 @@ AIC_ADDR_H = os.getenv("AIC_ADDR", "").strip()
 UM_ADDR_H  = os.getenv("UM_ADDR", "").strip()
 DECIMALS   = int(os.getenv("AIC_DECIMALS", "18"))
 
-# Para invocar con sncast
-SNCAST_BIN   = os.getenv("SNCAST_BIN", "sncast")
-SNCAST_ACCT  = os.getenv("SNCAST_ACCOUNT", "dev")
-SNCAST_FILE  = os.getenv("SNCAST_ACCOUNTS_FILE", os.path.expanduser("~/.starknet_accounts/starknet_open_zeppelin_accounts.json"))
-
 def _h(x: str | int) -> int:
-    if isinstance(x, int): return x
+    if isinstance(x, int):
+        return x
     s = str(x).strip()
     return int(s, 16) if s.startswith("0x") else int(s)
-
-def _to_u256(n: int) -> tuple[int,int]:
-    return (n & ((1<<128)-1), n >> 128)
 
 def _from_u256(lo: int, hi: int) -> int:
     return (hi << 128) + lo
@@ -52,71 +43,42 @@ def _require_env_addr(v: str, name: str) -> str:
         raise HTTPException(status_code=400, detail=f"{name} not configured")
     return v
 
-def _sncast_invoke(contract_addr_hex: str, fn: str, raw_calldata: list[str]) -> str:
-    args = [
-        SNCAST_BIN,
-        "--account", SNCAST_ACCT,
-        "--accounts-file", SNCAST_FILE,
-        "invoke",
-        "--url", RPC_URL,
-        "--contract-address", contract_addr_hex,
-        "--function", fn,
-        "--calldata", *raw_calldata,
-    ]
-    proc = subprocess.run(args, capture_output=True, text=True)
-    out = (proc.stdout or "") + "\n" + (proc.stderr or "")
-    if proc.returncode != 0:
-        raise HTTPException(status_code=500, detail=f"sncast invoke failed: {out.strip()[:800]}")
-    m = re.search(r"(?:Transaction Hash|transaction_hash)\s*:\s*(0x[0-9a-fA-F]+)", out)
-    if not m:
-        raise HTTPException(status_code=500, detail=f"tx hash not found in sncast output: {out.strip()[:800]}")
-    return m.group(1)
-
-app = FastAPI(title="tokenxllm backend", version="0.1.0")
+app = FastAPI(title="tokenxllm backend", version="0.2.0")
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5500","http://127.0.0.1:5500","null","*"],
+    allow_origins=["http://localhost:5500", "http://127.0.0.1:5500", "null", "*"],
     allow_methods=["*"],
     allow_headers=["*"],
     allow_credentials=False,
 )
 
-class Approve(BaseModel):
-    amount: float
-
-class Authorize(BaseModel):
-    units: int
-
-class Mint(BaseModel):
-    to: str
-    amount: float
-
 @app.get("/health")
-async def health(): return {"ok": True}
+async def health():
+    return {"ok": True}
 
 @app.get("/config")
 async def config():
     return {
         "rpc_url": RPC_URL,
         "aic_addr": AIC_ADDR_H or None,
-        "um_addr":  UM_ADDR_H  or None,
+        "um_addr": UM_ADDR_H or None,
         "decimals": DECIMALS,
-        "writes_enabled": bool(SNCAST_ACCT and SNCAST_FILE),
+        "writes_enabled": False,
     }
 
 @app.get("/balance")
 async def balance(user: str):
     aic = _require_env_addr(AIC_ADDR_H, "AIC_ADDR")
-    lo, hi = (await _read(aic, "balance_of", [_h(user)]) + [0,0])[:2]
+    lo, hi = (await _read(aic, "balance_of", [_h(user)]) + [0, 0])[:2]
     wei = _from_u256(lo, hi)
-    return {"balance_wei": str(wei), "balance_AIC": float(wei)/(10**DECIMALS)}
+    return {"balance_wei": str(wei), "balance_AIC": float(wei) / (10 ** DECIMALS)}
 
 @app.get("/allowance")
 async def allowance(owner: str, spender: str):
     aic = _require_env_addr(AIC_ADDR_H, "AIC_ADDR")
-    lo, hi = (await _read(aic, "allowance", [_h(owner), _h(spender)]) + [0,0])[:2]
+    lo, hi = (await _read(aic, "allowance", [_h(owner), _h(spender)]) + [0, 0])[:2]
     wei = _from_u256(lo, hi)
-    return {"allowance_wei": str(wei), "allowance_AIC": float(wei)/(10**DECIMALS)}
+    return {"allowance_wei": str(wei), "allowance_AIC": float(wei) / (10 ** DECIMALS)}
 
 @app.get("/used")
 async def used(user: str):
@@ -129,27 +91,3 @@ async def epoch():
     um = _require_env_addr(UM_ADDR_H, "UM_ADDR")
     (val,) = (await _read(um, "get_epoch_id", []) + [0])[:1]
     return {"epoch_id": int(val)}
-
-@app.post("/approve")
-async def approve(body: Approve):
-    aic = _require_env_addr(AIC_ADDR_H, "AIC_ADDR")
-    um  = _require_env_addr(UM_ADDR_H,  "UM_ADDR")
-    amount_wei = int(body.amount * (10**DECIMALS))
-    lo, hi = _to_u256(amount_wei)
-    txh = _sncast_invoke(aic, "approve", [um, str(lo), str(hi)])
-    return {"tx_hash": txh}
-
-@app.post("/authorize")
-async def authorize(body: Authorize):
-    um = _require_env_addr(UM_ADDR_H, "UM_ADDR")
-    txh = _sncast_invoke(um, "authorize_usage", [str(int(body.units))])
-    return {"tx_hash": txh}
-
-@app.post("/mint")
-async def mint(body: Mint):
-    aic = _require_env_addr(AIC_ADDR_H, "AIC_ADDR")
-    amount_wei = int(body.amount * (10**DECIMALS))
-    lo, hi = _to_u256(amount_wei)
-    txh = _sncast_invoke(aic, "mint", [body.to, str(lo), str(hi)])
-    return {"tx_hash": txh}
-#0x522570db5197d282febafea3538ff2deacfaf49ec85a86e30bbe45af6f7c90

--- a/tokenxllm/dashboard/frontend/app.js
+++ b/tokenxllm/dashboard/frontend/app.js
@@ -1,57 +1,309 @@
-async function api(base, path, opts){
-  const r = await fetch(`${base}${path}`, opts);
-  if(!r.ok){ throw new Error(await r.text()); }
-  return r.json();
+import { connect, disconnect } from "https://cdn.jsdelivr.net/npm/starknetkit@1.0.15/+esm";
+
+const state = {
+  apiBase: determineBaseUrl(),
+  config: null,
+  wallet: null,
+  account: null,
+  address: null,
+};
+
+const elements = {
+  config: document.getElementById("config"),
+  walletAddr: document.getElementById("walletAddr"),
+  backendBase: document.getElementById("backendBase"),
+  userAddr: document.getElementById("userAddr"),
+  txlog: document.getElementById("txlog"),
+  balance: document.getElementById("balance"),
+  allowance: document.getElementById("allowance"),
+  usage: document.getElementById("usage"),
+  btnConnect: document.getElementById("btnConnect"),
+  btnDisconnect: document.getElementById("btnDisconnect"),
+  btnRefresh: document.getElementById("btnRefresh"),
+  btnApprove: document.getElementById("btnApprove"),
+  btnAuthorize: document.getElementById("btnAuthorize"),
+  approveAmount: document.getElementById("approveAmount"),
+  authUnits: document.getElementById("authUnits"),
+};
+
+elements.backendBase.textContent = state.apiBase;
+updateWalletUi(false);
+
+function determineBaseUrl(){
+  const override = window.APP_BACKEND_BASE;
+  if(override){ return normalizeBase(String(override)); }
+  if(window.location.protocol === "file:"){ return "http://localhost:8000"; }
+  const port = window.location.port;
+  if(port && port !== "8000"){ return `${window.location.protocol}//${window.location.hostname}:8000`; }
+  return normalizeBase(window.location.origin || "http://localhost:8000");
 }
-function v(id){ return document.getElementById(id).value.trim(); }
-function set(id, txt){ document.getElementById(id).textContent = txt; }
 
-document.getElementById("btnConfig").onclick = async () => {
-  const base = v("baseUrl");
-  try { set("config", JSON.stringify(await api(base,"/config"), null, 2)); }
-  catch(e){ set("config", String(e)); }
-};
+function normalizeBase(url){
+  return url.replace(/\/+$/, "");
+}
 
-document.getElementById("btnRefresh").onclick = async () => {
-  const base = v("baseUrl"), user = v("userAddr");
-  if(!user){ alert("Enter your address"); return; }
+async function api(path, opts){
+  const url = `${state.apiBase}${path}`;
+  const res = await fetch(url, opts);
+  if(!res.ok){
+    const text = await res.text();
+    throw new Error(text || `${res.status} ${res.statusText}`);
+  }
+  return res.json();
+}
+
+function setText(el, value){
+  el.textContent = value;
+}
+
+function formatError(err){
+  if(err instanceof Error){ return err.message; }
+  if(typeof err === "string"){ return err; }
+  try{ return JSON.stringify(err); }
+  catch(_){ return String(err); }
+}
+
+async function loadConfig(){
   try{
-    const cfg = await api(base, "/config");
-    const bal = await api(base, `/balance?user=${user}`);
-    set("balance", `wei: ${bal.balance_wei}\nAIC: ${bal.balance_AIC}`);
-    if(cfg.um_addr){
-      const al = await api(base, `/allowance?owner=${user}&spender=${cfg.um_addr}`);
-      const used = await api(base, `/used?user=${user}`);
-      const ep = await api(base, `/epoch`);
-      set("allowance", `wei: ${al.allowance_wei}\nAIC: ${al.allowance_AIC}`);
-      set("usage", `used_units: ${used.used_units}\nepoch_id: ${ep.epoch_id}`);
-    }else{
-      set("allowance", "UM_ADDR not configured");
-      set("usage", "UM_ADDR not configured");
+    const cfg = await api("/config");
+    state.config = cfg;
+    setText(elements.config, JSON.stringify(cfg, null, 2));
+    return cfg;
+  }catch(err){
+    setText(elements.config, `config error: ${formatError(err)}`);
+    throw err;
+  }
+}
+
+async function ensureConfig(){
+  if(state.config){ return state.config; }
+  return loadConfig();
+}
+
+function updateWalletUi(connected){
+  if(connected){
+    const chain = state.wallet?.chainId ?? "unknown";
+    setText(elements.walletAddr, `${state.address}\nchain: ${chain}`);
+    setText(elements.userAddr, state.address || "");
+  }else{
+    setText(elements.walletAddr, "Not connected");
+    setText(elements.userAddr, "—");
+  }
+  elements.btnDisconnect.classList.toggle("hidden", !connected);
+  [elements.btnRefresh, elements.btnApprove, elements.btnAuthorize].forEach(btn => {
+    if(btn){ btn.disabled = !connected; }
+  });
+}
+
+async function attemptAutoConnect(){
+  try{
+    const result = await connect({ modalMode: "neverAsk" });
+    if(result && result.wallet){
+      applyWallet(result.wallet);
     }
-  }catch(e){ set("balance", String(e)); }
-};
+  }catch(err){
+    console.warn("auto connect failed", err);
+  }
+}
 
-document.getElementById("btnApprove").onclick = async () => {
-  const base = v("baseUrl"), amount = parseFloat(v("approveAmount"));
-  try{
-    const r = await api(base, "/approve", {method:"POST", headers:{'Content-Type':'application/json'}, body: JSON.stringify({amount})});
-    set("txlog", `approve tx: ${r.tx_hash}`);
-  }catch(e){ set("txlog", `approve error: ${e}`); }
-};
+function applyWallet(wallet){
+  state.wallet = wallet;
+  state.account = wallet.account;
+  state.address = wallet.selectedAddress || wallet.account?.address || null;
+  updateWalletUi(true);
+  refreshData().catch(() => {});
+}
 
-document.getElementById("btnAuthorize").onclick = async () => {
-  const base = v("baseUrl"), units = parseInt(v("authUnits"),10);
-  try{
-    const r = await api(base, "/authorize", {method:"POST", headers:{'Content-Type':'application/json'}, body: JSON.stringify({units})});
-    set("txlog", `authorize tx: ${r.tx_hash}`);
-  }catch(e){ set("txlog", `authorize error: ${e}`); }
-};
+function clearWallet(){
+  state.wallet = null;
+  state.account = null;
+  state.address = null;
+  updateWalletUi(false);
+}
 
-document.getElementById("btnMint").onclick = async () => {
-  const base = v("baseUrl"), to = v("mintTo"), amount = parseFloat(v("mintAmount"));
+async function refreshData(){
   try{
-    const r = await api(base, "/mint", {method:"POST", headers:{'Content-Type':'application/json'}, body: JSON.stringify({to, amount})});
-    set("txlog", `mint tx: ${r.tx_hash}`);
-  }catch(e){ set("txlog", `mint error: ${e}`); }
-};
+    ensureWallet();
+  }catch(_){
+    alert("Connect your wallet first");
+    return;
+  }
+  let cfg;
+  try{
+    cfg = await ensureConfig();
+  }catch(err){
+    setText(elements.balance, formatError(err));
+    return;
+  }
+  const user = encodeURIComponent(state.address);
+  try{
+    const bal = await api(`/balance?user=${user}`);
+    setText(elements.balance, `wei: ${bal.balance_wei}\nAIC: ${bal.balance_AIC}`);
+  }catch(err){
+    setText(elements.balance, `balance error: ${formatError(err)}`);
+  }
+  if(cfg.um_addr){
+    try{
+      const spender = encodeURIComponent(cfg.um_addr);
+      const [allowance, used, epoch] = await Promise.all([
+        api(`/allowance?owner=${user}&spender=${spender}`),
+        api(`/used?user=${user}`),
+        api(`/epoch`),
+      ]);
+      setText(elements.allowance, `wei: ${allowance.allowance_wei}\nAIC: ${allowance.allowance_AIC}`);
+      setText(elements.usage, `used_units: ${used.used_units}\nepoch_id: ${epoch.epoch_id}`);
+    }catch(err){
+      setText(elements.allowance, `allowance error: ${formatError(err)}`);
+      setText(elements.usage, `usage error: ${formatError(err)}`);
+    }
+  }else{
+    setText(elements.allowance, "UM_ADDR not configured");
+    setText(elements.usage, "UM_ADDR not configured");
+  }
+}
+
+function toUint256(value){
+  const mask = (1n << 128n) - 1n;
+  const lo = value & mask;
+  const hi = value >> 128n;
+  return [lo.toString(), hi.toString()];
+}
+
+function parseUnits(value, decimals){
+  const trimmed = String(value ?? "").trim();
+  if(!trimmed){ throw new Error("Enter an amount"); }
+  if(!/^\d*(\.\d*)?$/.test(trimmed)){ throw new Error("Invalid amount format"); }
+  const [wholeRaw, fracRaw = ""] = trimmed.split(".");
+  const base = 10n ** BigInt(decimals);
+  const whole = wholeRaw ? BigInt(wholeRaw) : 0n;
+  const fracPadded = (fracRaw + "0".repeat(decimals)).slice(0, decimals);
+  const fraction = fracPadded ? BigInt(fracPadded) : 0n;
+  return whole * base + fraction;
+}
+
+function ensureWallet(){
+  if(!state.wallet || !state.account || !state.address){
+    throw new Error("Connect your wallet first");
+  }
+  return state.wallet;
+}
+
+async function doApprove(){
+  let wallet;
+  try{
+    wallet = ensureWallet();
+  }catch(err){
+    setText(elements.txlog, formatError(err));
+    return;
+  }
+  let cfg;
+  try{
+    cfg = await ensureConfig();
+  }catch(err){
+    setText(elements.txlog, `config error: ${formatError(err)}`);
+    return;
+  }
+  if(!cfg.aic_addr || !cfg.um_addr){
+    setText(elements.txlog, "AIC_ADDR/UM_ADDR not configured");
+    return;
+  }
+  try{
+    const decimals = cfg.decimals ?? 18;
+    const weiAmount = parseUnits(elements.approveAmount.value, decimals);
+    const [lo, hi] = toUint256(weiAmount);
+    const { transaction_hash } = await wallet.account.execute({
+      contractAddress: cfg.aic_addr,
+      entrypoint: "approve",
+      calldata: [cfg.um_addr, lo, hi],
+    });
+    setText(elements.txlog, `approve tx: ${transaction_hash}`);
+  }catch(err){
+    setText(elements.txlog, `approve error: ${formatError(err)}`);
+  }
+}
+
+async function doAuthorize(){
+  let wallet;
+  try{
+    wallet = ensureWallet();
+  }catch(err){
+    setText(elements.txlog, formatError(err));
+    return;
+  }
+  let cfg;
+  try{
+    cfg = await ensureConfig();
+  }catch(err){
+    setText(elements.txlog, `config error: ${formatError(err)}`);
+    return;
+  }
+  if(!cfg.um_addr){
+    setText(elements.txlog, "UM_ADDR not configured");
+    return;
+  }
+  const unitsRaw = String(elements.authUnits.value ?? "").trim();
+  if(!unitsRaw){
+    setText(elements.txlog, "Enter units to authorize");
+    return;
+  }
+  let units;
+  try{
+    units = BigInt(unitsRaw);
+  }catch(err){
+    setText(elements.txlog, `Invalid units: ${formatError(err)}`);
+    return;
+  }
+  if(units < 0n){
+    setText(elements.txlog, "Units must be non-negative");
+    return;
+  }
+  try{
+    const { transaction_hash } = await wallet.account.execute({
+      contractAddress: cfg.um_addr,
+      entrypoint: "authorize_usage",
+      calldata: [units.toString()],
+    });
+    setText(elements.txlog, `authorize tx: ${transaction_hash}`);
+  }catch(err){
+    setText(elements.txlog, `authorize error: ${formatError(err)}`);
+  }
+}
+
+elements.btnConnect.addEventListener("click", async () => {
+  try{
+    const result = await connect({ modalMode: "alwaysAsk" });
+    if(result && result.wallet){
+      applyWallet(result.wallet);
+    }
+  }catch(err){
+    setText(elements.txlog, `wallet error: ${formatError(err)}`);
+  }
+});
+
+elements.btnDisconnect.addEventListener("click", async () => {
+  try{
+    await disconnect({ clearLastWallet: true });
+  }catch(err){
+    console.warn("disconnect error", err);
+  }
+  clearWallet();
+});
+
+document.getElementById("btnConfig").addEventListener("click", () => {
+  loadConfig().catch(() => {});
+});
+
+elements.btnRefresh.addEventListener("click", () => {
+  refreshData();
+});
+
+elements.btnApprove.addEventListener("click", () => {
+  doApprove();
+});
+
+elements.btnAuthorize.addEventListener("click", () => {
+  doAuthorize();
+});
+
+loadConfig().catch(() => {});
+attemptAutoConnect();

--- a/tokenxllm/dashboard/frontend/index.html
+++ b/tokenxllm/dashboard/frontend/index.html
@@ -1,64 +1,74 @@
 <!doctype html>
-<html lang="en"><head>
-<meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>TokenXLLM Dashboard</title>
-<link rel="stylesheet" href="style.css"/>
-</head><body>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>TokenXLLM Dashboard</title>
+  <link rel="stylesheet" href="style.css"/>
+</head>
+<body>
 <div class="wrap">
-<h1>TokenXLLM Dashboard</h1>
-<section class="card">
-  <h2>Backend</h2>
-  <label>Backend Base URL</label>
-  <input id="baseUrl" value="http://localhost:8000"/>
-  <button id="btnConfig">Load Config</button>
-  <pre id="config"></pre>
-</section>
+  <h1>TokenXLLM Dashboard</h1>
 
-<section class="card">
-  <h2>Monitor</h2>
-  <div class="grid">
-    <div>
-      <label>Your Address</label>
-      <input id="userAddr" placeholder="0x..."/>
+  <section class="card">
+    <h2>Wallet &amp; Backend</h2>
+    <div class="grid">
+      <div class="actions">
+        <button id="btnConnect">Connect Wallet</button>
+        <button id="btnDisconnect" class="secondary hidden">Disconnect</button>
+      </div>
+      <div>
+        <label>Selected account</label>
+        <pre id="walletAddr" class="mini"></pre>
+      </div>
     </div>
-    <div class="actions">
-      <button id="btnRefresh">Refresh</button>
+    <div class="grid compact">
+      <div>
+        <label>Backend base URL</label>
+        <pre id="backendBase" class="mini"></pre>
+      </div>
+      <div class="actions">
+        <button id="btnConfig">Reload Config</button>
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="box"><h3>Balance (AIC)</h3><pre id="balance"></pre></div>
-    <div class="box"><h3>Allowance → UM</h3><pre id="allowance"></pre></div>
-    <div class="box"><h3>Usage / Epoch</h3><pre id="usage"></pre></div>
-  </div>
-</section>
+    <pre id="config"></pre>
+  </section>
 
-<section class="card">
-  <h2>Actions</h2>
-  <div class="grid">
-    <div>
-      <label>Approve amount (AIC)</label>
-      <input id="approveAmount" type="number" step="0.000000000000000001" value="100"/>
-      <button id="btnApprove">Approve</button>
+  <section class="card">
+    <h2>Monitor</h2>
+    <div class="grid">
+      <div>
+        <label>Connected address</label>
+        <pre id="userAddr" class="mini"></pre>
+      </div>
+      <div class="actions">
+        <button id="btnRefresh">Refresh</button>
+      </div>
     </div>
-    <div>
-      <label>Authorize units</label>
-      <input id="authUnits" type="number" value="3000"/>
-      <button id="btnAuthorize">Authorize</button>
+    <div class="row">
+      <div class="box"><h3>Balance (AIC)</h3><pre id="balance"></pre></div>
+      <div class="box"><h3>Allowance → UM</h3><pre id="allowance"></pre></div>
+      <div class="box"><h3>Usage / Epoch</h3><pre id="usage"></pre></div>
     </div>
-  </div>
-  <div class="grid">
-    <div>
-      <label>Mint to (owner-only)</label>
-      <input id="mintTo" placeholder="0x..."/>
+  </section>
+
+  <section class="card">
+    <h2>Actions</h2>
+    <div class="grid">
+      <div>
+        <label>Approve amount (AIC)</label>
+        <input id="approveAmount" type="text" inputmode="decimal" value="100"/>
+        <button id="btnApprove">Approve</button>
+      </div>
+      <div>
+        <label>Authorize units</label>
+        <input id="authUnits" type="number" value="3000"/>
+        <button id="btnAuthorize">Authorize</button>
+      </div>
     </div>
-    <div>
-      <label>Mint amount (AIC)</label>
-      <input id="mintAmount" type="number" step="0.000000000000000001" value="50"/>
-      <button id="btnMint">Mint</button>
-    </div>
-  </div>
-  <pre id="txlog"></pre>
-</section>
+    <pre id="txlog"></pre>
+  </section>
 </div>
-<script src="app.js"></script>
-</body></html>
+<script type="module" src="app.js"></script>
+</body>
+</html>

--- a/tokenxllm/dashboard/frontend/style.css
+++ b/tokenxllm/dashboard/frontend/style.css
@@ -1,1 +1,24 @@
-*{box-sizing:border-box}body{margin:0;font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Arial}.wrap{max-width:1000px;margin:24px auto;padding:0 16px}.card{background:#fff;border:1px solid #e6e6e6;border-radius:12px;padding:16px;margin:16px 0}label{display:block;font-size:12px;color:#666;margin-bottom:4px}input{width:100%;padding:10px 12px;border:1px solid #d0d0d0;border-radius:10px;margin-bottom:8px}button{padding:10px 14px;border:1px solid #d0d0d0;background:#f9f9f9;border-radius:10px;cursor:pointer}button:hover{background:#f2f2f2}pre{background:#0b1020;color:#e3e8ff;padding:12px;border-radius:10px;overflow:auto}.grid{display:grid;grid-template-columns:1fr 1fr;gap:16px;align-items:end}.row{display:grid;grid-template-columns:1fr 1fr 1fr;gap:16px}.box{border:1px dashed #d9d9d9;border-radius:10px;padding:8px}@media (max-width:800px){.grid{grid-template-columns:1fr}.row{grid-template-columns:1fr}}
+* { box-sizing: border-box; }
+body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Arial; background: #f5f6fa; }
+.wrap { max-width: 1000px; margin: 24px auto; padding: 0 16px; }
+.card { background: #fff; border: 1px solid #e6e6e6; border-radius: 12px; padding: 16px; margin: 16px 0; box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04); }
+label { display: block; font-size: 12px; color: #666; margin-bottom: 4px; text-transform: uppercase; letter-spacing: 0.04em; }
+input { width: 100%; padding: 10px 12px; border: 1px solid #d0d0d0; border-radius: 10px; margin-bottom: 8px; font-size: 15px; }
+button { padding: 10px 14px; border: 1px solid #d0d0d0; background: #f9f9f9; border-radius: 10px; cursor: pointer; font-size: 14px; transition: background 0.15s ease; }
+button:hover { background: #f2f2f2; }
+button:disabled { opacity: 0.5; cursor: not-allowed; }
+button.secondary { background: #fff; }
+pre { background: #0b1020; color: #e3e8ff; padding: 12px; border-radius: 10px; overflow: auto; font-size: 13px; line-height: 1.4; }
+pre.mini { min-height: 48px; display: flex; align-items: center; }
+.grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; align-items: end; }
+.grid.compact { grid-template-columns: 2fr 1fr; align-items: center; }
+.actions { display: flex; gap: 8px; justify-content: flex-end; flex-wrap: wrap; }
+.row { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 16px; }
+.box { border: 1px dashed #d9d9d9; border-radius: 10px; padding: 8px; background: #fafbff; }
+.hidden { display: none !important; }
+@media (max-width: 800px) {
+  .grid { grid-template-columns: 1fr; align-items: stretch; }
+  .grid.compact { grid-template-columns: 1fr; }
+  .actions { justify-content: flex-start; }
+  .row { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Summary
- replace manual base URL and address inputs with a Starknet wallet connection flow that stores the selected account in the dashboard state
- send approve and authorize_usage transactions directly through the connected wallet, encoding amounts with a u256 helper before executing
- simplify the FastAPI backend to expose read-only endpoints now that client-side signing is available

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc764b35c483299851451fb92f12b0