### PR TITLE
Enable dashboard to run without bundler

### DIFF
--- a/tokenxllm/dashboard/frontend/index.html
+++ b/tokenxllm/dashboard/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>TokenXLLM Dashboard</title>
+    <link rel="stylesheet" href="./src/styles.css" />
   </head>
   <body>
     <div class="wrap">

--- a/tokenxllm/dashboard/frontend/src/clients/starknet.js
+++ b/tokenxllm/dashboard/frontend/src/clients/starknet.js
@@ -1,17 +1,56 @@
-import { RpcProvider } from "starknet";
-import { connect } from "starknetkit";
-import { appConfig } from "../config";
+import { appConfig } from "../config.js";
 
 let provider;
 
-export function getProvider() {
-  if (!provider && appConfig.rpcUrl) {
-    provider = new RpcProvider({ nodeUrl: appConfig.rpcUrl });
+let starknetModulesPromise;
+
+function loadStarknetModules() {
+  if (!starknetModulesPromise) {
+    starknetModulesPromise = (async () => {
+      try {
+        const [starknet, starknetkit] = await Promise.all([
+          import("starknet"),
+          import("starknetkit"),
+        ]);
+        return { RpcProvider: starknet.RpcProvider, connect: starknetkit.connect };
+      } catch (error) {
+        console.warn(
+          "Starknet libraries are unavailable; wallet features are disabled.",
+          error,
+        );
+        return { RpcProvider: null, connect: null };
+      }
+    })();
   }
+
+  return starknetModulesPromise;
+}
+
+function ensureProviderInitialized() {
+  if (provider || !appConfig.rpcUrl) {
+    return;
+  }
+
+  loadStarknetModules().then(({ RpcProvider }) => {
+    if (!provider && RpcProvider) {
+      provider = new RpcProvider({ nodeUrl: appConfig.rpcUrl });
+    }
+  });
+}
+
+export function getProvider() {
+  ensureProviderInitialized();
   return provider;
 }
 
 export async function connectWallet(options = {}) {
+  const { connect } = await loadStarknetModules();
+  if (typeof connect !== "function") {
+    throw new Error(
+      "Wallet connection is not available in this environment. Include the Starknet libraries to enable it.",
+    );
+  }
+
   return connect({
     modalMode: "neverAsk",
     dappName: "TokenXLLM Dashboard",

--- a/tokenxllm/dashboard/frontend/src/config.js
+++ b/tokenxllm/dashboard/frontend/src/config.js
@@ -1,7 +1,15 @@
 const sanitize = (value) => (typeof value === "string" ? value.trim() : value);
 
+const env = (() => {
+  try {
+    return (import.meta && import.meta.env) || {};
+  } catch (error) {
+    return {};
+  }
+})();
+
 const parsedDecimals = (() => {
-  const raw = sanitize(import.meta.env.VITE_DECIMALS);
+  const raw = sanitize(env.VITE_DECIMALS);
   if (raw === undefined || raw === null || raw === "") {
     return undefined;
   }
@@ -10,10 +18,10 @@ const parsedDecimals = (() => {
 })();
 
 export const appConfig = {
-  backendUrl: sanitize(import.meta.env.VITE_BACKEND_URL) || "",
-  rpcUrl: sanitize(import.meta.env.VITE_RPC_URL) || "",
-  aicAddress: sanitize(import.meta.env.VITE_AIC_ADDR) || "",
-  umAddress: sanitize(import.meta.env.VITE_UM_ADDR) || "",
+  backendUrl: sanitize(env.VITE_BACKEND_URL) || "",
+  rpcUrl: sanitize(env.VITE_RPC_URL) || "",
+  aicAddress: sanitize(env.VITE_AIC_ADDR) || "",
+  umAddress: sanitize(env.VITE_UM_ADDR) || "",
   decimals: parsedDecimals ?? 18,
 };
 

--- a/tokenxllm/dashboard/frontend/src/dashboard.js
+++ b/tokenxllm/dashboard/frontend/src/dashboard.js
@@ -9,7 +9,7 @@ import {
   getUsedUnits,
   mint,
 } from "./services/backend.js";
-import { connectWallet, getProvider } from "./clients/starknet";
+import { connectWallet, getProvider } from "./clients/starknet.js";
 
 let backendConfig = null;
 let writesEnabled = false;

--- a/tokenxllm/dashboard/frontend/src/main.js
+++ b/tokenxllm/dashboard/frontend/src/main.js
@@ -1,4 +1,3 @@
-import "./styles.css";
 import { initDashboard } from "./dashboard.js";
 
 initDashboard();

--- a/tokenxllm/dashboard/frontend/src/services/backend.js
+++ b/tokenxllm/dashboard/frontend/src/services/backend.js
@@ -1,4 +1,4 @@
-import { appConfig, assertBackendConfigured } from "../config";
+import { appConfig, assertBackendConfigured } from "../config.js";
 
 async function request(path, options = {}) {
   assertBackendConfigured();


### PR DESCRIPTION
## Summary
- load dashboard styles through a standard link tag so the page renders when served statically
- guard environment variable reads and browser module imports to avoid runtime errors without a bundler
- update relative imports with explicit extensions for native module resolution

## Testing
- python -m http.server 4173 (manual smoke test)

------
https://chatgpt.com/codex/tasks/task_e_68cccd0c13e88329934adaa60bad7cbf