### PR TITLE
Add free vs paid usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,15 @@ python tokenxllm.py authorize --units 3000
 python tokenxllm.py used
 python tokenxllm.py epoch
 
+Ejemplo paso a paso del flujo de cuota gratis vs pagada:
+
+```
+python examples/free_vs_paid/example_free_paid.py
+```
+
+El directorio `examples/free_vs_paid/` incluye una guía con los requisitos y
+cómo interpretar los cambios en `used_in_current_epoch` y la `allowance`.
+
 9) Dashboard – Backend (FastAPI)
 cd dashboard/backend
 python3 -m venv venv

--- a/examples/free_vs_paid/README.md
+++ b/examples/free_vs_paid/README.md
@@ -1,0 +1,59 @@
+# Free vs Paid Usage Walkthrough
+
+This example shows how to observe the free quota and paid transfer behaviour of the `UsageManager` contract. It assumes you already deployed the contracts and configured the CLI described in the project README.
+
+## Prerequisites
+
+Before running the script:
+
+1. Deploy the AIC ERC-20 token and the `UsageManager` contract, noting the deployed addresses.
+2. Mint AIC to the account that will sign the transactions and approve the `UsageManager` to spend enough tokens to cover the paid portion of the demo. The helper CLI exposes convenient commands:
+   ```bash
+   python tokenxllm/tokenxllm.py mint --amount 100          # optional, only owner can mint
+   python tokenxllm/tokenxllm.py approve --amount 90        # allow UM to pull 90 AIC (wei)
+   python tokenxllm/tokenxllm.py allowance                  # verify the allowance in wei and tokens
+   ```
+3. Set the environment variables consumed by `tokenxllm.py` (they can live in a `.env` file):
+   ```bash
+   export RPC_URL=...
+   export AIC_ADDR=0x...
+   export UM_ADDR=0x...
+   export ACCOUNT_ADDRESS=0x...
+   export PRIVATE_KEY=0x...
+   export AIC_DECIMALS=18
+   ```
+   The `ACCOUNT_ADDRESS`/`PRIVATE_KEY` pair (or an entry in `~/.starknet_accounts/...`) must have an allowance configured for the `UsageManager` contract.
+
+## Recap of the contract rules
+
+`UsageManager.authorize_usage` tracks usage per account and epoch. For each call the contract:
+
+- Reads the caller's `used_in_current_epoch` and the configured `free_quota_per_epoch`.
+- Computes the remaining free units and splits the requested `units` between free and paid portions.
+- Transfers `paid_units * price_per_unit_wei` from the caller to the treasury using `AIC.transfer_from` when the paid portion is greater than zero.
+- Stores the new usage total for `(caller, epoch)` so subsequent calls can see the updated consumption.
+
+See [`src/contracts/usage/UsageManager.cairo`](../../tokenxllm/src/contracts/usage/UsageManager.cairo) for the full implementation.
+
+## Running the walkthrough
+
+1. Inspect the current usage and allowance for your account:
+   ```bash
+   python tokenxllm/tokenxllm.py used
+   python tokenxllm/tokenxllm.py allowance
+   ```
+   The example expects some free quota to remain in the current epoch so it can demonstrate both behaviours. If the free quota is exhausted, wait for the next epoch or lower the first call's units with the `--free-call-units` flag.
+2. Run the example script (it defaults to one free-sized call followed by a paid call that exceeds the free quota):
+   ```bash
+   python examples/free_vs_paid/example_free_paid.py
+   ```
+   You can override the unit counts if you need to adapt to your own quota configuration:
+   ```bash
+   python examples/free_vs_paid/example_free_paid.py --free-call-units 500 --paid-call-units 2500
+   ```
+3. Check the usage tracker again to verify the changes made by the script:
+   ```bash
+   python tokenxllm/tokenxllm.py used
+   ```
+   The script prints the allowance deltas so you can confirm that the first call did not consume allowance while the second call triggered the ERC-20 `transfer_from` for the paid units.
+

--- a/examples/free_vs_paid/example_free_paid.py
+++ b/examples/free_vs_paid/example_free_paid.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Demonstrate the free-versus-paid behaviour of UsageManager.authorize_usage."""
+
+import argparse
+import asyncio
+import os
+from decimal import Decimal, getcontext
+
+from starknet_py.hash.storage import get_storage_var_address
+
+from tokenxllm.tokenxllm import (
+    call_u64,
+    call_u256,
+    do_authorize,
+    make_client_and_account,
+    resolve_address,
+    req,
+    h,
+)
+
+getcontext().prec = 60
+
+
+def format_tokens(value: int, scale: Decimal) -> str:
+    return f"{Decimal(value) / scale:f}"
+
+
+async def read_free_quota(client, usage_manager_hex: str) -> int:
+    key = get_storage_var_address("UsageManager_free_quota_per_epoch")
+    return await client.get_storage_at(contract_address=h(usage_manager_hex), key=key)
+
+
+async def read_price_per_unit(client, usage_manager_hex: str) -> int:
+    base_key = get_storage_var_address("UsageManager_price_per_unit_wei")
+    low = await client.get_storage_at(contract_address=h(usage_manager_hex), key=base_key)
+    high = await client.get_storage_at(contract_address=h(usage_manager_hex), key=base_key + 1)
+    return (high << 128) + low
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Call authorize_usage twice to show how free quota and paid transfers interact."
+    )
+    parser.add_argument(
+        "--free-call-units",
+        type=int,
+        default=None,
+        help="Units for the first (free) authorize_usage call. Default: stays within remaining free quota.",
+    )
+    parser.add_argument(
+        "--paid-call-units",
+        type=int,
+        default=None,
+        help="Units for the second (paid) authorize_usage call. Default: exceeds the free quota.",
+    )
+    args = parser.parse_args()
+
+    client, account = await make_client_and_account()
+    print(f"Signer account: 0x{account.address:064x}")
+
+    owner_hex = resolve_address(None)
+    if owner_hex.lower() != f"0x{account.address:064x}".lower():
+        print(f"Resolved address for usage tracking: {owner_hex}")
+
+    aic_addr = req("AIC_ADDR")
+    um_addr = req("UM_ADDR")
+    decimals = int(os.getenv("AIC_DECIMALS", "18"))
+    scale = Decimal(10) ** decimals
+
+    free_quota = await read_free_quota(client, um_addr)
+    price_per_unit_wei = await read_price_per_unit(client, um_addr)
+    price_per_unit_tokens = Decimal(price_per_unit_wei) / scale
+
+    print(f"Free quota per epoch: {free_quota} units")
+    print(
+        "Price per paid unit: "
+        f"{price_per_unit_wei} wei ({format_tokens(price_per_unit_wei, scale)} AIC)"
+    )
+
+    used_before = await call_u64(client, um_addr, "used_in_current_epoch", [h(owner_hex)])
+    allowance_before = await call_u256(
+        client, aic_addr, "allowance", [h(owner_hex), h(um_addr)]
+    )
+
+    free_remaining_before = max(free_quota - used_before, 0)
+    print(
+        "used_in_current_epoch before: "
+        f"{used_before} units (free remaining: {free_remaining_before})"
+    )
+    print(
+        "Allowance before: "
+        f"{allowance_before} wei ({format_tokens(allowance_before, scale)} AIC)"
+    )
+
+    if args.free_call_units is not None:
+        free_call_units = args.free_call_units
+    else:
+        if free_remaining_before == 0:
+            raise RuntimeError(
+                "No free quota remaining in the current epoch. "
+                "Pass --free-call-units to override or wait for the next epoch."
+            )
+        free_call_units = min(free_remaining_before, max(free_quota // 2, 1))
+
+    if free_call_units < 0:
+        raise ValueError("free-call-units must be non-negative")
+    if free_call_units > free_remaining_before:
+        print(
+            "Warning: first call requests more units than the remaining free quota. "
+            "The demo may not show a purely free call."
+        )
+
+    print(
+        f"\nCalling authorize_usage({free_call_units}) for the free-quota scenario..."
+    )
+    await do_authorize(free_call_units)
+
+    used_after_free = await call_u64(
+        client, um_addr, "used_in_current_epoch", [h(owner_hex)]
+    )
+    allowance_after_free = await call_u256(
+        client, aic_addr, "allowance", [h(owner_hex), h(um_addr)]
+    )
+
+    used_delta_free = used_after_free - used_before
+    allowance_delta_free = allowance_before - allowance_after_free
+
+    print(
+        "After first call: "
+        f"used={used_after_free} (delta {used_delta_free}), "
+        f"allowance delta={allowance_delta_free} wei"
+    )
+    if allowance_delta_free == 0:
+        print("As expected, the free portion did not consume any allowance.")
+    else:
+        print(
+            "Warning: allowance changed during the free call (check your quota configuration)."
+        )
+
+    free_remaining_after_free = max(free_quota - used_after_free, 0)
+
+    if args.paid_call_units is not None:
+        paid_call_units = args.paid_call_units
+    else:
+        paid_call_units = free_quota + max(free_quota // 2, 1)
+
+    if paid_call_units <= free_remaining_after_free:
+        paid_call_units = free_remaining_after_free + 1
+        print(
+            "Adjusted paid-call-units to "
+            f"{paid_call_units} to exceed remaining free quota."
+        )
+
+    if paid_call_units < 0:
+        raise ValueError("paid-call-units must be non-negative")
+
+    print(f"\nCalling authorize_usage({paid_call_units}) for the paid scenario...")
+    await do_authorize(paid_call_units)
+
+    used_after_paid = await call_u64(
+        client, um_addr, "used_in_current_epoch", [h(owner_hex)]
+    )
+    allowance_after_paid = await call_u256(
+        client, aic_addr, "allowance", [h(owner_hex), h(um_addr)]
+    )
+
+    used_delta_paid_call = used_after_paid - used_after_free
+    allowance_delta_paid = allowance_after_free - allowance_after_paid
+
+    free_consumed_second = min(paid_call_units, free_remaining_after_free)
+    paid_units = paid_call_units - free_consumed_second
+    expected_cost = price_per_unit_wei * paid_units
+
+    print(
+        "After second call: "
+        f"used={used_after_paid} (delta {used_delta_paid_call}), "
+        f"allowance delta={allowance_delta_paid} wei"
+    )
+    print(
+        "Paid units in second call: "
+        f"{paid_units} (free carried over: {free_consumed_second})"
+    )
+    print(
+        "Expected cost: "
+        f"{expected_cost} wei ({format_tokens(expected_cost, scale)} AIC)"
+    )
+    if allowance_delta_paid == expected_cost:
+        print("Allowance drop matches the on-chain price configuration.")
+    else:
+        print(
+            "Warning: allowance delta does not match the expected paid cost. "
+            "Double-check the quota and price configuration."
+        )
+
+    print(
+        "\nFinal allowance: "
+        f"{allowance_after_paid} wei ({format_tokens(allowance_after_paid, scale)} AIC)"
+    )
+    print(f"Final used_in_current_epoch: {used_after_paid} units")
+    print(
+        "\nYou can re-run `python tokenxllm/tokenxllm.py used` and "
+        "`python tokenxllm/tokenxllm.py allowance` to cross-check the values above."
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add a walkthrough under `examples/free_vs_paid/` documenting the prerequisites and contract behaviour
- provide a Python script that calls `authorize_usage` below and above the free quota so the allowance delta shows the paid transfer
- link the new example from the main README for quicker discovery

## Testing
- python -m compileall examples/free_vs_paid/example_free_paid.py

------
https://chatgpt.com/codex/tasks/task_e_68cd7da68db08329bd1a7f725b7bf8e8