### PR TITLE
Expose free quota API and demo spending UI

### DIFF
--- a/tokenxllm/dashboard/frontend/index.html
+++ b/tokenxllm/dashboard/frontend/index.html
@@ -72,6 +72,28 @@
         </div>
       </section>
 
+      <section class="card card-free-demo">
+        <h2>Demo gasto gratis</h2>
+        <div class="free-demo-grid">
+          <div class="free-demo-controls">
+            <button id="btnConnectWallet" type="button">Conectar billetera</button>
+            <label for="freeSpendUnits">Unidades a gastar</label>
+            <input id="freeSpendUnits" type="number" min="1" step="1" />
+            <button id="btnSpendFree" type="button">Gastar gratis</button>
+          </div>
+          <div class="free-demo-stats">
+            <div class="stat-card">
+              <span class="stat-label">Cuota gratuita disponible</span>
+              <span class="stat-value" id="freeQuotaInfo">Sin datos</span>
+            </div>
+            <div class="stat-card">
+              <span class="stat-label">Unidades pagadas / costo estimado</span>
+              <span class="stat-value" id="paidUsageInfo">0 / 0 AIC</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <section class="card">
         <h2>Actions</h2>
         <div class="grid">

--- a/tokenxllm/dashboard/frontend/src/services/backend.js
+++ b/tokenxllm/dashboard/frontend/src/services/backend.js
@@ -42,6 +42,11 @@ export function getUsedUnits(userAddress) {
   return request(`/used?user=${encodeURIComponent(userAddress)}`);
 }
 
+export function getFreeQuota(userAddress) {
+  const query = userAddress ? `?user=${encodeURIComponent(userAddress)}` : "";
+  return request(`/free_quota${query}`);
+}
+
 export function getEpoch() {
   return request(`/epoch`);
 }

--- a/tokenxllm/dashboard/frontend/src/styles.css
+++ b/tokenxllm/dashboard/frontend/src/styles.css
@@ -108,12 +108,64 @@ pre {
   align-items: flex-end;
 }
 
+.card-free-demo .free-demo-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+  gap: 16px;
+  align-items: stretch;
+}
+
+.card-free-demo .free-demo-controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  align-items: end;
+}
+
+.card-free-demo .free-demo-controls button {
+  width: 100%;
+}
+
+.free-demo-stats {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+}
+
+.stat-card {
+  background: linear-gradient(135deg, #eef2ff, #e0e7ff);
+  border-radius: 12px;
+  padding: 16px;
+  border: 1px solid #c7d2fe;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.stat-label {
+  display: block;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #4c51bf;
+  margin-bottom: 6px;
+}
+
+.stat-value {
+  font-size: 20px;
+  font-weight: 600;
+  color: #1a237e;
+  word-break: break-word;
+}
+
 @media (max-width: 800px) {
   .grid {
     grid-template-columns: 1fr;
   }
 
   .row {
+    grid-template-columns: 1fr;
+  }
+
+  .card-free-demo .free-demo-grid {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- read UsageManager storage keys to expose `/free_quota` with quota totals and price metadata
- add frontend service and demo workflow to fetch quota, connect a wallet, and spend units with paid usage tracking
- style the dashboard to highlight free quota status and paid consumption counters

## Testing
- npm --prefix tokenxllm/dashboard/frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68cded6635f88329890e28408bb41a55