### PR TITLE
Add Vercel configuration for dashboard backend

### DIFF
--- a/api/backend.py
+++ b/api/backend.py
@@ -1,0 +1,3 @@
+from tokenxllm.dashboard.backend.main import app
+
+handler = app

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "functions": {
+    "api/backend.py": {
+      "runtime": "vercel-python@3"
+    }
+  },
+  "installCommand": "pip install -r tokenxllm/tokenxllm/dashboard/backend/requirements.txt"
+}


### PR DESCRIPTION
## Summary
- expose the dashboard backend FastAPI application via an `api/backend.py` handler for Vercel
- configure `vercel.json` to use the Python runtime and install the dashboard backend requirements

## Testing
- not run (configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68d0933c156c832982defd3ca5348a0e