### PR TITLE
Add configurable dashboard origin for production CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ RPC_URL=https://starknet-sepolia.public.blastapi.io/rpc/v0_9
 AIC_ADDR=0x06ddaf09636ceb526485c55b93c48c70f2a1728ad223743aaf08c21362ae7d9e
 UM_ADDR=0x04515dc0c7ccb8c2816cd95ca16db10eb3c8071dafea05414fd078c4dc41473a
 AIC_DECIMALS=18
+# Opcional: lista separada por comas de orígenes permitidos además de localhost
+DASHBOARD_PUBLIC_URL=https://tu-dashboard.vercel.app
 # Para habilitar botones de escritura (approve/authorize/mint):
 ACCOUNT_ADDRESS=0x522570db5197d282febafea3538ff2deacfaf49ec85a86e30bbe45af6f7c90
 PRIVATE_KEY=0x<tu_privada_hex>
@@ -248,6 +250,8 @@ Class not declared al deploy
 No expongas el backend con writes_enabled=true a internet.
 
 Limitá CORS (allow_origins) a tu dominio.
+
+Si desplegás el backend en Vercel, agregá en **Settings → Environment Variables** una variable `DASHBOARD_PUBLIC_URL` con el dominio público de tu frontend (por ejemplo `https://tu-dashboard.vercel.app`). También podés listar varios orígenes separados por comas si necesitás más de un dominio.
 
 Considerá .env fuera del repo y rotación periódica de claves.
 

--- a/tokenxllm/dashboard/backend/.env.example
+++ b/tokenxllm/dashboard/backend/.env.example
@@ -2,6 +2,7 @@ RPC_URL=https://starknet-sepolia.public.blastapi.io/rpc/v0_9
 AIC_ADDR=0x06ddaf09636ceb526485c55b93c48c70f2a1728ad223743aaf08c21362ae7d9e
 UM_ADDR=0x04515dc0c7ccb8c2816cd95ca16db10eb3c8071dafea05414fd078c4dc41473a
 AIC_DECIMALS=18
+DASHBOARD_PUBLIC_URL=https://your-dashboard.vercel.app
 
 ACCOUNT_ADDRESS=0x522570db5197d282febafea3538ff2deacfaf49ec85a86e30bbe45af6f7c90
 PRIVATE_KEY=0x<tu_privada_hex>

--- a/tokenxllm/dashboard/backend/README.md
+++ b/tokenxllm/dashboard/backend/README.md
@@ -1,1 +1,16 @@
 Run with uvicorn after filling .env (copy from .env.example).
+
+## Environment variables
+
+| Name | Description |
+| --- | --- |
+| `RPC_URL` | Starknet RPC endpoint. |
+| `AIC_ADDR` | Address of the AIC ERC-20 contract. |
+| `UM_ADDR` | Address of the UsageManager contract. |
+| `AIC_DECIMALS` | Decimal precision for the AIC token. |
+| `ACCOUNT_ADDRESS` / `PRIVATE_KEY` | Optional pair used to enable write operations from the dashboard. |
+| `DASHBOARD_PUBLIC_URL` | Optional comma-separated list of additional CORS origins. Set this to the public URL that serves the frontend (e.g. `https://your-dashboard.vercel.app`). |
+
+### Deploying on Vercel
+
+If you host the backend on Vercel, add an Environment Variable named `DASHBOARD_PUBLIC_URL` with the public domain of your deployed frontend (e.g. `https://your-dashboard.vercel.app`). This ensures the backend accepts requests from the production dashboard while keeping CORS restrictions in place.


### PR DESCRIPTION
## Summary
- allow configuring extra CORS origins for the dashboard backend via a new `DASHBOARD_PUBLIC_URL` environment variable
- document the variable in the backend README, `.env.example`, and the main deployment guide (including Vercel instructions)

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0933e5a0083299b6f4c6faf726763