### PR TITLE
Add faucet support to dashboard backend and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,12 +183,24 @@ DASHBOARD_PUBLIC_URL=https://tu-dashboard.vercel.app
 # Para habilitar botones de escritura (approve/authorize/mint):
 ACCOUNT_ADDRESS=0x522570db5197d282febafea3538ff2deacfaf49ec85a86e30bbe45af6f7c90
 PRIVATE_KEY=0x<tu_privada_hex>
+# Faucet opcional
+FAUCET_ENABLED=true
+FAUCET_AMOUNT_AIC=50
+FAUCET_COOLDOWN_SECONDS=86400
 EOF
 
 uvicorn main:app --host 0.0.0.0 --port 8000
 
 
 Tip: si no ponés ACCOUNT_ADDRESS/PRIVATE_KEY, writes_enabled=false y el front puede deshabilitar acciones que firman.
+
+Si habilitás el faucet:
+
+- La cuenta configurada en ACCOUNT_ADDRESS/PRIVATE_KEY debe ser la dueña del AIC para poder mintear.
+- Enviá algo de ETH de Sepolia a esa cuenta para cubrir fees.
+- Los parámetros se leen en `/faucet` (GET) y el reclamo se hace con `POST /faucet` enviando `{ "to": "0x..." }`.
+- El backend aplica un cooldown por address basado en `FAUCET_COOLDOWN_SECONDS`.
+- El endpoint `/config` incluye un bloque `faucet` con esta información para el dashboard.
 
 10) Dashboard – Frontend
 
@@ -197,6 +209,8 @@ Desde Windows o Ubuntu (en carpeta dashboard/frontend):
 # Servir el HTML por HTTP (evita “TypeError: Failed to fetch” del esquema file://)
 cd dashboard/frontend
 python3 -m http.server 5500
+
+En el dashboard verás una tarjeta "Faucet" con el estado actual, el monto por reclamo y el cooldown restante para la dirección ingresada. El botón "Reclamar faucet" usa el backend para mintear el monto configurado (si el faucet está habilitado y no estás en cooldown).
 
 
 Abrí en el navegador:

--- a/tokenxllm/dashboard/backend/tests/test_main.py
+++ b/tokenxllm/dashboard/backend/tests/test_main.py
@@ -25,6 +25,7 @@ def _decimal_to_wei_parts(value: Decimal) -> tuple[int, int, int]:
 @pytest.fixture(autouse=True)
 def _stub_required_addresses(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(main, "_require_env_addr", lambda _value, _name: "0xabc")
+    monkeypatch.setattr(main, "_FAUCET_LAST_CLAIMS", {})
 
 
 def test_balance_large_value_precision(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -59,3 +60,88 @@ def test_allowance_large_value_precision(monkeypatch: pytest.MonkeyPatch) -> Non
     assert payload["allowance_AIC"] == EXPECTED_DECIMAL_STR
     assert isinstance(payload["allowance_AIC"], str)
     assert Decimal(payload["allowance_AIC"]) == LARGE_DECIMAL
+
+
+def test_config_includes_faucet(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(main, "FAUCET_ENABLED", True)
+    monkeypatch.setattr(main, "FAUCET_COOLDOWN_SECONDS", 3600)
+    monkeypatch.setattr(main, "FAUCET_AMOUNT_AIC", Decimal("123.45"))
+    monkeypatch.setattr(main, "_writes_enabled", lambda: True)
+    monkeypatch.setattr(main, "_account_address_hex", lambda: "0xbeef")
+
+    payload = asyncio.run(main.config())
+    faucet = payload.get("faucet")
+    assert faucet is not None
+    assert faucet["enabled"] is True
+    assert faucet["writes_enabled"] is True
+    assert faucet["cooldown_seconds"] == 3600
+    assert faucet["amount_AIC"] == "123.45"
+    expected_wei = str(main._tokens_to_wei(Decimal("123.45"), main.DECIMALS))
+    assert faucet["amount_wei"] == expected_wei
+
+
+def test_faucet_request_requires_writes(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(main, "FAUCET_ENABLED", True)
+    monkeypatch.setattr(main, "FAUCET_COOLDOWN_SECONDS", 10)
+    monkeypatch.setattr(main, "FAUCET_AMOUNT_AIC", Decimal("1"))
+    monkeypatch.setattr(main, "_writes_enabled", lambda: False)
+
+    with pytest.raises(main.HTTPException) as excinfo:
+        asyncio.run(main.faucet_request(main.FaucetRequest(to="0x1")))
+
+    assert excinfo.value.status_code == 400
+
+
+def test_faucet_request_enforces_cooldown(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(main, "FAUCET_ENABLED", True)
+    monkeypatch.setattr(main, "FAUCET_COOLDOWN_SECONDS", 120)
+    monkeypatch.setattr(main, "FAUCET_AMOUNT_AIC", Decimal("5"))
+    monkeypatch.setattr(main, "_writes_enabled", lambda: True)
+
+    current_time = {"value": 1000.0}
+
+    def fake_now() -> float:
+        return current_time["value"]
+
+    monkeypatch.setattr(main, "_current_timestamp", fake_now)
+
+    tx_calls: list[tuple[str, str, list[int]]] = []
+
+    async def fake_invoke(addr: str, fn: str, calldata: list[int]) -> str:
+        tx_calls.append((addr, fn, calldata))
+        return "0xdead"
+
+    monkeypatch.setattr(main, "_invoke", fake_invoke)
+
+    request = main.FaucetRequest(to="0x123")
+
+    expected_amount = main._tokens_to_wei(Decimal("5"), main.DECIMALS)
+    expected_lo, expected_hi = main._to_u256(expected_amount)
+
+    first_response = asyncio.run(main.faucet_request(request))
+    assert first_response["tx_hash"] == "0xdead"
+    assert first_response["seconds_remaining"] == main.FAUCET_COOLDOWN_SECONDS
+    assert tx_calls == [("0xabc", "mint", [main._h("0x123"), expected_lo, expected_hi])]
+
+    stored = main._FAUCET_LAST_CLAIMS.get("0x123".lower())
+    assert stored == pytest.approx(1000.0)
+
+    current_time["value"] = 1000.0 + main.FAUCET_COOLDOWN_SECONDS - 1
+
+    with pytest.raises(main.HTTPException) as excinfo:
+        asyncio.run(main.faucet_request(request))
+
+    assert excinfo.value.status_code == 429
+    detail = excinfo.value.detail
+    assert isinstance(detail, dict)
+    assert detail["seconds_remaining"] > 0
+    assert main._FAUCET_LAST_CLAIMS.get("0x123".lower()) == pytest.approx(1000.0)
+
+    current_time["value"] = 1000.0 + main.FAUCET_COOLDOWN_SECONDS + 1
+    second_response = asyncio.run(main.faucet_request(request))
+    assert second_response["tx_hash"] == "0xdead"
+    assert tx_calls == [
+        ("0xabc", "mint", [main._h("0x123"), expected_lo, expected_hi]),
+        ("0xabc", "mint", [main._h("0x123"), expected_lo, expected_hi]),
+    ]
+    assert main._FAUCET_LAST_CLAIMS.get("0x123".lower()) == pytest.approx(current_time["value"])

--- a/tokenxllm/dashboard/frontend/index.html
+++ b/tokenxllm/dashboard/frontend/index.html
@@ -94,6 +94,42 @@
         </div>
       </section>
 
+      <section class="card card-faucet">
+        <h2>Faucet</h2>
+        <div class="faucet-stats">
+          <div class="stat-card">
+            <span class="stat-label">Estado</span>
+            <span class="stat-value" id="faucetEnabled">Deshabilitado</span>
+          </div>
+          <div class="stat-card">
+            <span class="stat-label">Monto por reclamo</span>
+            <span class="stat-value" id="faucetAmount">N/D</span>
+          </div>
+          <div class="stat-card">
+            <span class="stat-label">Cooldown</span>
+            <span class="stat-value" id="faucetCooldown">N/D</span>
+          </div>
+          <div class="stat-card">
+            <span class="stat-label">Tiempo restante</span>
+            <span class="stat-value" id="faucetRemaining">N/D</span>
+          </div>
+          <div class="stat-card">
+            <span class="stat-label">Último reclamo</span>
+            <span class="stat-value" id="faucetLastClaim">Sin datos</span>
+          </div>
+        </div>
+        <div class="grid faucet-form">
+          <div>
+            <label>Dirección a fondear</label>
+            <input id="faucetAddress" placeholder="0x..." />
+          </div>
+          <div class="actions">
+            <button id="btnFaucet" type="button">Reclamar faucet</button>
+          </div>
+        </div>
+        <pre id="faucetStatus"></pre>
+      </section>
+
       <section class="card">
         <h2>Actions</h2>
         <div class="grid">

--- a/tokenxllm/dashboard/frontend/src/services/backend.js
+++ b/tokenxllm/dashboard/frontend/src/services/backend.js
@@ -71,3 +71,15 @@ export function mint(to, amount) {
     body: JSON.stringify({ to, amount }),
   });
 }
+
+export function getFaucetInfo(address) {
+  const query = address ? `?address=${encodeURIComponent(address)}` : "";
+  return request(`/faucet${query}`);
+}
+
+export function requestFaucet(address) {
+  return request(`/faucet`, {
+    method: "POST",
+    body: JSON.stringify({ to: address }),
+  });
+}

--- a/tokenxllm/dashboard/frontend/src/styles.css
+++ b/tokenxllm/dashboard/frontend/src/styles.css
@@ -156,6 +156,21 @@ pre {
   word-break: break-word;
 }
 
+.card-faucet .faucet-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.card-faucet .faucet-form {
+  margin-top: 8px;
+}
+
+.card-faucet pre {
+  margin-top: 12px;
+}
+
 @media (max-width: 800px) {
   .grid {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- add faucet configuration, cooldown tracking and new GET/POST endpoints to the dashboard backend and expose the state in /config
- extend backend tests to cover faucet responses and cooldown behaviour while stubbing invoke/time
- surface faucet info and claim actions in the dashboard UI/services and document the new flow and environment variables

## Testing
- pytest tokenxllm/dashboard/backend/tests/test_main.py

------
https://chatgpt.com/codex/tasks/task_e_68d0c34a65cc83299a46d212b8b69f04