### PR TITLE
Update Vercel deployment commands

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,11 +1,8 @@
 {
-{
-  "buildCommand": "npm ci --prefix tokenxllm/tokenxllm/dashboard/frontend && npm run build --prefix tokenxllm/tokenxllm/dashboard/frontend",
-  "outputDirectory": "tokenxllm/tokenxllm/dashboard/frontend/dist",
+  "buildCommand": "npm ci --prefix tokenxllm/dashboard/frontend && npm run build --prefix tokenxllm/dashboard/frontend",
+  "installCommand": "pip install -r requirements.txt",
+  "outputDirectory": "tokenxllm/dashboard/frontend/dist",
   "rewrites": [
     { "source": "/api/(.*)", "destination": "/api/$1" }
   ]
-}
-
-  "installCommand": "pip install -r tokenxllm/tokenxllm/dashboard/backend/requirements.txt"
 }


### PR DESCRIPTION
## Summary
- replace `vercel.json` with a valid configuration defining install, build, and output settings for the dashboard frontend while preserving API rewrites

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d34a195a98832993c197a421b022c3