### PR TITLE
Document separate dashboard deployments and fix package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,13 @@ Si habilitás el faucet:
 
 - La cuenta configurada en ACCOUNT_ADDRESS/PRIVATE_KEY debe ser la dueña del AIC para poder mintear.
 - Enviá algo de ETH de Sepolia a esa cuenta para cubrir fees.
+
+10) Despliegue del dashboard
+
+- **Frontend (Vercel estático)**: usa el directorio `dashboard/frontend` como raíz del proyecto. Configurá `npm run build` como comando de build y `dist` como output. Cargá las variables `VITE_*` (en especial `VITE_BACKEND_URL`) desde el panel de Vercel para que el bundle conozca dónde vive el backend.
+- **Backend (Vercel Python o servicio equivalente)**: se despliega por separado con `dashboard/backend` como proyecto FastAPI. Instalá dependencias con `pip install -r requirements.txt`, ejecutá `uvicorn main:app` y definí en Vercel las variables `RPC_URL`, `AIC_ADDR`, `UM_ADDR`, `AIC_DECIMALS` y `DASHBOARD_PUBLIC_URL` (dominio público del frontend). Esto mantiene el CORS limitado al dashboard y a `http://localhost:5173`.
+
+> Podés alojar el backend en cualquier otro proveedor (Railway, Render, un VPS). Sólo asegurate de actualizar `VITE_BACKEND_URL` en el frontend para apuntar al dominio correcto.
 - Los parámetros se leen en `/faucet` (GET) y el reclamo se hace con `POST /faucet` enviando `{ "to": "0x..." }`.
 - El backend aplica un cooldown por address basado en `FAUCET_COOLDOWN_SECONDS`.
 - El endpoint `/config` incluye un bloque `faucet` con esta información para el dashboard.

--- a/dashboard/backend/README.md
+++ b/dashboard/backend/README.md
@@ -13,4 +13,13 @@ Run with uvicorn after filling .env (copy from .env.example).
 
 ### Deploying on Vercel
 
-If you host the backend on Vercel, add an Environment Variable named `DASHBOARD_PUBLIC_URL` with the public domain of your deployed frontend (e.g. `https://your-dashboard.vercel.app`). This ensures the backend accepts requests from the production dashboard while keeping CORS restrictions in place.
+The backend runs as a standalone FastAPI service. To host it on Vercel:
+
+1. Create a **separate** Vercel project from the `dashboard/backend` directory.
+2. Set the build command to `pip install -r requirements.txt` and the run command to `uvicorn main:app` (Vercel automatically wraps it as a serverless function).
+3. Add the environment variables listed above (at minimum `RPC_URL`, `AIC_ADDR`, `UM_ADDR`, `AIC_DECIMALS`).
+4. Define `DASHBOARD_PUBLIC_URL` with the public domain(s) of your frontend (comma separated if you have multiple). They will be appended to the CORS allow-list together with `http://localhost:5173` for local development.
+
+> Because the backend exposes private write operations when `ACCOUNT_ADDRESS`/`PRIVATE_KEY` are present, avoid committing those values. Configure them directly in the Vercel dashboard if you need to enable writes.
+
+Once the backend deployment succeeds, update the frontend environment variable `VITE_BACKEND_URL` so that the dashboard points to the newly created API.

--- a/dashboard/frontend/README.md
+++ b/dashboard/frontend/README.md
@@ -43,3 +43,14 @@ npm run preview
 ```
 
 The `build` command outputs static assets to `dist/`. Use `npm run preview` to serve the production build locally.
+
+## Deploying to Vercel
+
+You can deploy the frontend as a static site:
+
+1. Create a new Vercel project using the `dashboard/frontend` folder as the root.
+2. Set the build command to `npm run build` and the output directory to `dist`.
+3. Define the environment variables that start with `VITE_` (at least `VITE_BACKEND_URL`, `VITE_RPC_URL`, `VITE_AIC_ADDR`, `VITE_UM_ADDR` and `VITE_DECIMALS`). Vercel will expose them at build time.
+4. Point `VITE_BACKEND_URL` to the URL where you host the FastAPI backend (local testing, another Vercel project, Railway, Render, etc.).
+
+> The frontend and backend must be deployed as separate projects. Once the backend is live, add its public URL to `VITE_BACKEND_URL` and trigger a new frontend build.

--- a/dashboard/frontend/package.json
+++ b/dashboard/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview --port 4173"
   },
   "dependencies": {
     "get-starknet": "^4.0.0",
@@ -15,10 +15,5 @@
   },
   "devDependencies": {
     "vite": "^5.4.20"
-  },
- "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview --port 4173"
   }
 }


### PR DESCRIPTION
## Summary
- fix the dashboard frontend package.json so that it contains a single scripts block with a preview port compatible with Vercel
- document how to deploy the frontend to Vercel as a static project and reference the required VITE_* variables
- extend the backend and root READMEs with instructions for deploying the FastAPI service separately (including CORS and environment variables)

## Testing
- npm run build (dashboard/frontend)


------
https://chatgpt.com/codex/tasks/task_e_68d360820f3c8329b41dea4cbb2effe3