### PR TITLE
Add usage statistics tab to dashboard

### DIFF
--- a/dashboard/frontend/index.html
+++ b/dashboard/frontend/index.html
@@ -9,155 +9,233 @@
   <body>
     <div class="wrap">
       <h1>TokenXLLM Dashboard</h1>
-      <section class="card">
-        <h2>Environment</h2>
-        <div class="env-grid">
-          <div>
-            <h3>Backend URL</h3>
-            <code id="backendUrl"></code>
-          </div>
-          <div>
-            <h3>RPC URL</h3>
-            <code id="rpcUrl"></code>
-          </div>
-          <div>
-            <h3>TokenXLlm Address</h3>
-            <code id="tokenXllmAddress"></code>
-            <code id="aicAddress"></code>
-          </div>
-          <div>
-            <h3>UM Address</h3>
-            <code id="umAddress"></code>
-          </div>
-          <div>
-            <h3>Decimals</h3>
-            <code id="decimals"></code>
-          </div>
-          <div>
-            <h3>Writes Enabled</h3>
-            <code id="writesEnabled"></code>
-          </div>
-          <div>
-            <h3>Signer Address</h3>
-            <code id="signerAddress"></code>
-          </div>
+      <div class="tab-container">
+        <div class="tab-bar" role="tablist">
+          <button
+            type="button"
+            class="tab-button is-active"
+            data-tab-target="overview"
+            role="tab"
+            aria-selected="true"
+          >
+            General
+          </button>
+          <button
+            type="button"
+            class="tab-button"
+            data-tab-target="usage"
+            role="tab"
+            aria-selected="false"
+            tabindex="-1"
+          >
+            Estadísticas de uso
+          </button>
         </div>
-        <button id="btnConfig">Load Config</button>
-        <pre id="config"></pre>
-      </section>
+        <div class="tab-panels">
+          <div class="tab-content is-active" data-tab-panel="overview">
+            <section class="card">
+              <h2>Environment</h2>
+              <div class="env-grid">
+                <div>
+                  <h3>Backend URL</h3>
+                  <code id="backendUrl"></code>
+                </div>
+                <div>
+                  <h3>RPC URL</h3>
+                  <code id="rpcUrl"></code>
+                </div>
+                <div>
+                  <h3>TokenXLlm Address</h3>
+                  <code id="tokenXllmAddress"></code>
+                  <code id="aicAddress"></code>
+                </div>
+                <div>
+                  <h3>UM Address</h3>
+                  <code id="umAddress"></code>
+                </div>
+                <div>
+                  <h3>Decimals</h3>
+                  <code id="decimals"></code>
+                </div>
+                <div>
+                  <h3>Writes Enabled</h3>
+                  <code id="writesEnabled"></code>
+                </div>
+                <div>
+                  <h3>Signer Address</h3>
+                  <code id="signerAddress"></code>
+                </div>
+              </div>
+              <button id="btnConfig">Load Config</button>
+              <pre id="config"></pre>
+            </section>
 
-      <section class="card">
-        <h2>Monitor</h2>
-        <div class="grid">
-          <div>
-            <label>Your Address</label>
-            <input id="userAddr" placeholder="0x..." />
-          </div>
-          <div class="actions">
-            <button id="btnRefresh">Refresh</button>
-          </div>
-        </div>
-        <div class="row">
-          <div class="box">
-            <h3>Balance (AIC)</h3>
-            <pre id="balance"></pre>
-          </div>
-          <div class="box">
-            <h3>Allowance → UM</h3>
-            <pre id="allowance"></pre>
-          </div>
-          <div class="box">
-            <h3>Usage / Epoch</h3>
-            <pre id="usage"></pre>
-          </div>
-        </div>
-      </section>
+            <section class="card">
+              <h2>Monitor</h2>
+              <div class="grid">
+                <div>
+                  <label>Your Address</label>
+                  <input id="userAddr" placeholder="0x..." />
+                </div>
+                <div class="actions">
+                  <button id="btnRefresh">Refresh</button>
+                </div>
+              </div>
+              <div class="row">
+                <div class="box">
+                  <h3>Balance (AIC)</h3>
+                  <pre id="balance"></pre>
+                </div>
+                <div class="box">
+                  <h3>Allowance → UM</h3>
+                  <pre id="allowance"></pre>
+                </div>
+                <div class="box">
+                  <h3>Usage / Epoch</h3>
+                  <pre id="usage"></pre>
+                </div>
+              </div>
+            </section>
 
-      <section class="card card-free-demo">
-        <h2>Demo gasto gratis</h2>
-        <div class="free-demo-grid">
-          <div class="free-demo-controls">
-            <button id="btnConnectWallet" type="button">Conectar billetera</button>
-            <label for="freeSpendUnits">Unidades a gastar</label>
-            <input id="freeSpendUnits" type="number" min="1" step="1" />
-            <button id="btnSpendFree" type="button">Gastar gratis</button>
-          </div>
-          <div class="free-demo-stats">
-            <div class="stat-card">
-              <span class="stat-label">Cuota gratuita disponible</span>
-              <span class="stat-value" id="freeQuotaInfo">Sin datos</span>
-            </div>
-            <div class="stat-card">
-              <span class="stat-label">Unidades pagadas / costo estimado</span>
-              <span class="stat-value" id="paidUsageInfo">0 / 0 AIC</span>
-            </div>
-          </div>
-        </div>
-      </section>
+            <section class="card card-free-demo">
+              <h2>Demo gasto gratis</h2>
+              <div class="free-demo-grid">
+                <div class="free-demo-controls">
+                  <button id="btnConnectWallet" type="button">Conectar billetera</button>
+                  <label for="freeSpendUnits">Unidades a gastar</label>
+                  <input id="freeSpendUnits" type="number" min="1" step="1" />
+                  <button id="btnSpendFree" type="button">Gastar gratis</button>
+                </div>
+                <div class="free-demo-stats">
+                  <div class="stat-card">
+                    <span class="stat-label">Cuota gratuita disponible</span>
+                    <span class="stat-value" id="freeQuotaInfo">Sin datos</span>
+                  </div>
+                  <div class="stat-card">
+                    <span class="stat-label">Unidades pagadas / costo estimado</span>
+                    <span class="stat-value" id="paidUsageInfo">0 / 0 AIC</span>
+                  </div>
+                </div>
+              </div>
+            </section>
 
-      <section class="card card-faucet">
-        <h2>Faucet</h2>
-        <div class="faucet-stats">
-          <div class="stat-card">
-            <span class="stat-label">Estado</span>
-            <span class="stat-value" id="faucetEnabled">Deshabilitado</span>
-          </div>
-          <div class="stat-card">
-            <span class="stat-label">Monto por reclamo</span>
-            <span class="stat-value" id="faucetAmount">N/D</span>
-          </div>
-          <div class="stat-card">
-            <span class="stat-label">Cooldown</span>
-            <span class="stat-value" id="faucetCooldown">N/D</span>
-          </div>
-          <div class="stat-card">
-            <span class="stat-label">Tiempo restante</span>
-            <span class="stat-value" id="faucetRemaining">N/D</span>
-          </div>
-          <div class="stat-card">
-            <span class="stat-label">Último reclamo</span>
-            <span class="stat-value" id="faucetLastClaim">Sin datos</span>
-          </div>
-        </div>
-        <div class="grid faucet-form">
-          <div>
-            <label>Dirección a fondear</label>
-            <input id="faucetAddress" placeholder="0x..." />
-          </div>
-          <div class="actions">
-            <button id="btnFaucet" type="button">Reclamar faucet</button>
-          </div>
-        </div>
-        <pre id="faucetStatus"></pre>
-      </section>
+            <section class="card card-faucet">
+              <h2>Faucet</h2>
+              <div class="faucet-stats">
+                <div class="stat-card">
+                  <span class="stat-label">Estado</span>
+                  <span class="stat-value" id="faucetEnabled">Deshabilitado</span>
+                </div>
+                <div class="stat-card">
+                  <span class="stat-label">Monto por reclamo</span>
+                  <span class="stat-value" id="faucetAmount">N/D</span>
+                </div>
+                <div class="stat-card">
+                  <span class="stat-label">Cooldown</span>
+                  <span class="stat-value" id="faucetCooldown">N/D</span>
+                </div>
+                <div class="stat-card">
+                  <span class="stat-label">Tiempo restante</span>
+                  <span class="stat-value" id="faucetRemaining">N/D</span>
+                </div>
+                <div class="stat-card">
+                  <span class="stat-label">Último reclamo</span>
+                  <span class="stat-value" id="faucetLastClaim">Sin datos</span>
+                </div>
+              </div>
+              <div class="grid faucet-form">
+                <div>
+                  <label>Dirección a fondear</label>
+                  <input id="faucetAddress" placeholder="0x..." />
+                </div>
+                <div class="actions">
+                  <button id="btnFaucet" type="button">Reclamar faucet</button>
+                </div>
+              </div>
+              <pre id="faucetStatus"></pre>
+            </section>
 
-      <section class="card">
-        <h2>Actions</h2>
-        <div class="grid">
-          <div>
-            <label>Approve amount (AIC)</label>
-            <input id="approveAmount" type="number" />
-            <button id="btnApprove">Approve</button>
+            <section class="card">
+              <h2>Actions</h2>
+              <div class="grid">
+                <div>
+                  <label>Approve amount (AIC)</label>
+                  <input id="approveAmount" type="number" />
+                  <button id="btnApprove">Approve</button>
+                </div>
+                <div>
+                  <label>Authorize units</label>
+                  <input id="authUnits" type="number" />
+                  <button id="btnAuthorize">Authorize</button>
+                </div>
+              </div>
+              <div class="grid">
+                <div>
+                  <label>Mint to (owner-only)</label>
+                  <input id="mintTo" placeholder="0x..." />
+                </div>
+                <div>
+                  <label>Mint amount (AIC)</label>
+                  <input id="mintAmount" type="number" />
+                  <button id="btnMint">Mint</button>
+                </div>
+              </div>
+              <pre id="txlog"></pre>
+            </section>
           </div>
-          <div>
-            <label>Authorize units</label>
-            <input id="authUnits" type="number" />
-            <button id="btnAuthorize">Authorize</button>
+          <div class="tab-content" data-tab-panel="usage" hidden>
+            <section class="card card-usage">
+              <h2>Estadísticas de uso por billetera</h2>
+              <p class="usage-description">
+                Agregá direcciones para monitorear cuántas unidades consumieron en la época actual
+                y cuánta cuota gratuita les queda disponible.
+              </p>
+              <div class="usage-controls">
+                <div>
+                  <label for="usageAddressInput">Dirección</label>
+                  <input id="usageAddressInput" placeholder="0x..." autocomplete="off" />
+                </div>
+                <div>
+                  <label for="usageAddressLabel">Alias (opcional)</label>
+                  <input id="usageAddressLabel" placeholder="Equipo, cliente, etc." autocomplete="off" />
+                </div>
+                <div class="actions">
+                  <button id="btnAddUsageAddress" type="button">Agregar billetera</button>
+                </div>
+              </div>
+              <div class="usage-actions">
+                <div>
+                  <button id="btnRefreshUsageStats" type="button">Actualizar estadísticas</button>
+                  <button id="btnClearUsageStats" type="button" class="secondary">Limpiar lista</button>
+                </div>
+                <div class="usage-epoch" id="usageEpochInfo">Época actual: sin datos</div>
+              </div>
+              <div class="usage-table-wrapper">
+                <table class="usage-table">
+                  <thead>
+                    <tr>
+                      <th scope="col">Alias</th>
+                      <th scope="col">Dirección</th>
+                      <th scope="col" class="numeric">Unidades usadas</th>
+                      <th scope="col" class="numeric">Gratis restantes</th>
+                      <th scope="col" class="numeric">Gratis totales</th>
+                      <th scope="col" class="numeric">Pagas estimadas</th>
+                      <th scope="col">Última actualización</th>
+                      <th scope="col">Estado</th>
+                      <th scope="col">Acciones</th>
+                    </tr>
+                  </thead>
+                  <tbody id="usageStatsBody">
+                    <tr class="usage-empty">
+                      <td colspan="9">Agregá una dirección para comenzar a monitorear el uso.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </section>
           </div>
         </div>
-        <div class="grid">
-          <div>
-            <label>Mint to (owner-only)</label>
-            <input id="mintTo" placeholder="0x..." />
-          </div>
-          <div>
-            <label>Mint amount (AIC)</label>
-            <input id="mintAmount" type="number" />
-            <button id="btnMint">Mint</button>
-          </div>
-        </div>
-        <pre id="txlog"></pre>
-      </section>
+      </div>
     </div>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/dashboard/frontend/src/styles.css
+++ b/dashboard/frontend/src/styles.css
@@ -19,6 +19,52 @@ h1 {
   margin-bottom: 16px;
 }
 
+.tab-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.tab-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.tab-button {
+  padding: 10px 18px;
+  border: 1px solid #d0d0d0;
+  border-radius: 999px;
+  background: #f4f4f5;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.tab-button:hover,
+.tab-button:focus {
+  outline: none;
+  border-color: #a5b4fc;
+  background: #eef2ff;
+  color: #312e81;
+}
+
+.tab-button.is-active {
+  background: linear-gradient(135deg, #4338ca, #6366f1);
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 6px 14px rgba(99, 102, 241, 0.25);
+}
+
+.tab-panels {
+  display: flex;
+  flex-direction: column;
+}
+
+.tab-content {
+  width: 100%;
+}
+
 .card {
   background: #fff;
   border: 1px solid #e6e6e6;
@@ -55,6 +101,16 @@ button {
 
 button:hover {
   background: #f2f2f2;
+}
+
+button.secondary {
+  background: #fff7ed;
+  border-color: #fed7aa;
+  color: #9a3412;
+}
+
+button.secondary:hover {
+  background: #ffedd5;
 }
 
 pre {
@@ -171,6 +227,139 @@ pre {
   margin-top: 12px;
 }
 
+.card-usage .usage-description {
+  margin-top: 0;
+  margin-bottom: 18px;
+  color: #4b5563;
+  font-size: 14px;
+}
+
+.usage-controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  align-items: end;
+}
+
+.usage-actions {
+  margin-top: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.usage-epoch {
+  font-size: 13px;
+  color: #4338ca;
+  font-weight: 600;
+}
+
+.usage-epoch.error {
+  color: #b91c1c;
+}
+
+.usage-table-wrapper {
+  margin-top: 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  background: #fff;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+}
+
+.usage-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+}
+
+.usage-table thead {
+  background: #eef2ff;
+}
+
+.usage-table th,
+.usage-table td {
+  padding: 12px 14px;
+  border-bottom: 1px solid #e5e7eb;
+  font-size: 13px;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.usage-table th.numeric,
+.usage-table td.numeric {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.usage-table tbody tr:hover {
+  background: #f9fafb;
+}
+
+.usage-table code {
+  background: #f3f4f6;
+  border-radius: 6px;
+  padding: 4px 6px;
+  display: inline-block;
+  word-break: break-all;
+}
+
+.usage-table .usage-empty td {
+  text-align: center;
+  color: #6b7280;
+  font-style: italic;
+}
+
+.link-button {
+  border: none;
+  background: none;
+  color: #4338ca;
+  padding: 0;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.link-button:hover,
+.link-button:focus {
+  text-decoration: underline;
+  outline: none;
+}
+
+.usage-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 500;
+  font-size: 12px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: #ede9fe;
+  color: #5b21b6;
+}
+
+.usage-status-ok {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.usage-status-loading {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.usage-status-error {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.usage-status-muted {
+  background: #e5e7eb;
+  color: #4b5563;
+}
+
 @media (max-width: 800px) {
   .grid {
     grid-template-columns: 1fr;
@@ -182,5 +371,14 @@ pre {
 
   .card-free-demo .free-demo-grid {
     grid-template-columns: 1fr;
+  }
+
+  .usage-actions {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .usage-table {
+    min-width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- add tab navigation to the dashboard layout to host multiple views
- implement a usage statistics tab that tracks wallet consumption, persists addresses, and refreshes data from the backend
- extend styling to support tab controls and the usage table presentation

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e32bd9ddf883299793b8f4f9cb8f7a