### PR TITLE
Fix TokenXLLM address display on dashboard

### DIFF
--- a/dashboard/frontend/index.html
+++ b/dashboard/frontend/index.html
@@ -45,7 +45,7 @@
                   <code id="rpcUrl"></code>
                 </div>
                 <div>
-                  <h3>TokenXLlm Address</h3>
+                  <h3>TokenXLLM Address</h3>
                   <code id="tokenXllmAddress"></code>
                   <code id="aicAddress"></code>
                 </div>

--- a/dashboard/frontend/src/dashboard.js
+++ b/dashboard/frontend/src/dashboard.js
@@ -830,7 +830,9 @@ async function authorizeWithWallet(units) {
 function updateEnvironmentSection() {
   setText("backendUrl", appConfig.backendUrl || "Not configured");
   setText("rpcUrl", appConfig.rpcUrl || "Not configured");
-  setText("aicAddress", appConfig.aicAddress || "Not configured");
+  const tokenAddressValue = appConfig.aicAddress || "Not configured";
+  setText("tokenXllmAddress", tokenAddressValue);
+  setText("aicAddress", tokenAddressValue);
   setText("umAddress", appConfig.umAddress || "Not configured");
   setText("decimals", String(appConfig.decimals));
   applyWriteAvailability(writesEnabled);


### PR DESCRIPTION
## Summary
- correct the TokenXLLM environment label spelling
- populate the TokenXLLM address field using the configured token address

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f06cb2f90c8329bffec4473576a0c1